### PR TITLE
feat: Add beginner contribution guides, practice area, and GitHub community files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,19 @@
+---
+name: Bug Report
+about: Report a broken link, typo, or error in the guides
+title: "[Bug] "
+labels: bug
+assignees: ''
+---
+
+**What's wrong?**
+A clear description of the issue.
+
+**Where is it?**
+Link to the file or section (e.g., `guides/02-setting-up-git.md`, line 15).
+
+**What should it say instead?**
+The correct content or expected behavior.
+
+**Additional context**
+Any other details, screenshots, or links that might help.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature Request
+about: Suggest a new guide, improvement, or idea
+title: "[Idea] "
+labels: enhancement
+assignees: ''
+---
+
+**What's your idea?**
+A clear description of what you'd like to see added or changed.
+
+**Why would this help?**
+How would this benefit new contributors?
+
+**Additional context**
+Any examples, links, or references that might be useful.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## What does this PR do?
+
+A brief description of your changes.
+
+## Type of change
+
+- [ ] Adding my contributor profile
+- [ ] Fixing a typo or broken link
+- [ ] Improving an existing guide
+- [ ] Adding a new guide or resource
+- [ ] Other (describe below)
+
+## Checklist
+
+- [ ] I have read the [Contributing Guide](../CONTRIBUTING.md)
+- [ ] My changes follow the project's style and formatting
+- [ ] I have tested that links and markdown render correctly
+- [ ] This is my own original work

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,31 @@
+name: Welcome New Contributors
+
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
+            Welcome to Learn to Contribute! Thanks for opening your first issue here.
+
+            A maintainer will take a look soon. In the meantime, check out our [guides](../../tree/main/guides) if you haven't already.
+
+            Happy contributing!
+          pr-message: |
+            Welcome to Learn to Contribute! Thanks for opening your first pull request here.
+
+            A maintainer will review your changes soon. While you wait, make sure you've checked the boxes in the PR template above.
+
+            Congratulations on taking the first step into open source! Once you're ready for more, check out [OSS Notify](https://www.ossnotify.com) to find issues matched to your skills.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**support@ossnotify.com**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/),
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to Learn to Contribute
+
+First off, thank you for considering contributing! This project exists to help people like you get started with open source, so every contribution matters.
+
+## Ways to Contribute
+
+### Add Your Profile (Beginner)
+The easiest way to make your first contribution is to add your profile to the [contributors/](contributors/) directory. Follow the instructions in [contributors/README.md](contributors/README.md).
+
+### Improve the Guides (Intermediate)
+Found a typo? Think a step could be clearer? Guides live in the [guides/](guides/) directory. Improvements of any size are welcome.
+
+### Suggest New Content (Any Level)
+Have an idea for a new guide or feature? [Open an issue](../../issues) and let us know.
+
+### Review Pull Requests (Intermediate)
+Help other contributors by reviewing their pull requests. Leave kind, constructive feedback.
+
+## How to Submit a Contribution
+
+### 1. Fork the Repository
+
+Click the **Fork** button at the top right of this page to create your own copy of the repository.
+
+### 2. Clone Your Fork
+
+```bash
+git clone https://github.com/YOUR-USERNAME/LearnToContribute.git
+cd LearnToContribute
+```
+
+### 3. Create a Branch
+
+```bash
+git checkout -b your-branch-name
+```
+
+Use a descriptive branch name like `add-profile-yourname` or `fix-typo-guide-03`.
+
+### 4. Make Your Changes
+
+Edit or add files as needed. Keep changes focused — one contribution per pull request.
+
+### 5. Commit Your Changes
+
+```bash
+git add .
+git commit -m "A short description of what you changed"
+```
+
+Write clear commit messages. Describe **what** you did and **why**.
+
+### 6. Push to Your Fork
+
+```bash
+git push origin your-branch-name
+```
+
+### 7. Open a Pull Request
+
+Go to the original repository on GitHub and click **New Pull Request**. Select your branch and fill out the PR template.
+
+## Guidelines
+
+- **Be kind and respectful.** Follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+- **Keep it simple.** Small, focused contributions are easier to review and merge.
+- **Ask questions.** If you're unsure about something, open an issue or comment on an existing one.
+- **Test your changes.** Make sure your markdown renders correctly and links work.
+
+## Need Help?
+
+- Read through the [guides](guides/) for step-by-step instructions
+- [Open an issue](../../issues) if you're stuck
+- Use [OSS Notify](https://www.ossnotify.com) to find more open source issues matched to your skills

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Learn to Contribute
+
+Welcome! This is a beginner-friendly repository designed to help you make your first open source contribution. Whether you've never used Git before or just need a refresher, you're in the right place.
+
+This project is brought to you by [OSS Notify](https://www.ossnotify.com) — a service that matches developers with open source issues based on their skills.
+
+## What's Inside
+
+**[Guides](guides/)** — Step-by-step tutorials that walk you through everything from setting up Git to submitting your first pull request.
+
+1. [What is Open Source?](guides/01-what-is-open-source.md)
+2. [Setting Up Git](guides/02-setting-up-git.md)
+3. [Forking and Cloning](guides/03-forking-and-cloning.md)
+4. [Making Your First Pull Request](guides/04-making-your-first-pr.md)
+5. [Understanding Issues](guides/05-understanding-issues.md)
+6. [Finding Issues with OSS Notify](guides/06-using-oss-notify.md)
+
+**[Contributors](contributors/)** — A practice area where you can make your very first contribution by adding your profile. This is a real pull request to a real repo — the perfect way to learn.
+
+## Getting Started
+
+1. **Read the guides** — Start with [What is Open Source?](guides/01-what-is-open-source.md) and work your way through
+2. **Add your profile** — Follow the instructions in [contributors/](contributors/) to submit your first PR
+3. **Find more issues** — Use [OSS Notify](https://www.ossnotify.com) to discover issues matched to your skills
+
+Check out our [Contributing Guide](CONTRIBUTING.md) for detailed instructions on how to contribute to this project.
+
+## How to Contribute
+
+There are many ways to contribute, no matter your experience level:
+
+- **Add your profile** to the [contributors/](contributors/) directory
+- **Improve a guide** — fix typos, clarify steps, or add tips
+- **Suggest a new guide** — open an [issue](../../issues) with your idea
+- **Help other contributors** — review pull requests and answer questions
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the full guide.
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+
+---
+
+Built with care by [OSS Notify](https://www.ossnotify.com) — issue alerts matched to your skills.

--- a/contributors/README.md
+++ b/contributors/README.md
@@ -1,0 +1,72 @@
+# Contributors
+
+Welcome! This is where you make your first open source contribution.
+
+Add your profile by creating a JSON file in this directory. It's a real pull request to a real repository — and a great way to practice the workflow.
+
+## How to Add Your Profile
+
+### 1. Fork and Clone
+
+If you haven't already, [fork this repository](https://github.com/ossnotify/LearnToContribute/fork) and clone it to your computer:
+
+```bash
+git clone https://github.com/YOUR-USERNAME/LearnToContribute.git
+cd LearnToContribute
+```
+
+### 2. Create a Branch
+
+```bash
+git checkout -b add-profile-YOUR-USERNAME
+```
+
+### 3. Copy the Template
+
+```bash
+cp contributors/example.json contributors/YOUR-USERNAME.json
+```
+
+### 4. Edit Your Profile
+
+Open `contributors/YOUR-USERNAME.json` and fill it in:
+
+```json
+{
+  "name": "Your Name",
+  "github": "your-github-username",
+  "skills": ["JavaScript", "Python", "React"],
+  "message": "Hello from my first open source contribution!"
+}
+```
+
+**Guidelines:**
+- Use your actual GitHub username as the filename
+- List 1-5 skills or technologies you know or are learning
+- Keep your message friendly and appropriate
+- Don't modify other contributors' files
+
+### 5. Commit and Push
+
+```bash
+git add contributors/YOUR-USERNAME.json
+git commit -m "Add contributor profile for YOUR-USERNAME"
+git push origin add-profile-YOUR-USERNAME
+```
+
+### 6. Open a Pull Request
+
+Go to the original repository on GitHub and click **Compare & pull request**. Fill out the template and submit.
+
+That's it! A maintainer will review and merge your profile.
+
+## Need Help?
+
+- Read the full guide: [Making Your First Pull Request](../guides/04-making-your-first-pr.md)
+- [Open an issue](../../issues) if you're stuck
+
+## Contributors
+
+Thanks to everyone who has contributed!
+
+<!-- Contributors will appear here as profiles are added -->

--- a/contributors/example.json
+++ b/contributors/example.json
@@ -1,0 +1,6 @@
+{
+  "name": "Your Name",
+  "github": "your-github-username",
+  "skills": ["JavaScript", "Python"],
+  "message": "Excited to start contributing to open source!"
+}

--- a/guides/01-what-is-open-source.md
+++ b/guides/01-what-is-open-source.md
@@ -1,0 +1,46 @@
+# What is Open Source?
+
+Open source software is software whose source code is publicly available for anyone to view, use, modify, and share. Some of the most important software in the world is open source — including Linux, Firefox, VS Code, and millions of libraries that power modern applications.
+
+## Why Does Open Source Matter?
+
+- **Transparency** — Anyone can inspect the code to understand how it works
+- **Collaboration** — Developers from around the world work together to improve software
+- **Learning** — Reading and contributing to real projects is one of the best ways to grow as a developer
+- **Impact** — Your contribution can help thousands or even millions of users
+
+## Why Contribute?
+
+Contributing to open source is one of the most rewarding things you can do as a developer:
+
+- **Learn by doing** — Work on real codebases with real users
+- **Build your portfolio** — Contributions show up on your GitHub profile
+- **Meet people** — Join a global community of developers
+- **Get better at collaboration** — Practice code review, Git workflows, and communication
+- **Give back** — Help maintain the tools you use every day
+
+## What Counts as a Contribution?
+
+Contributing isn't just about writing code. There are many ways to help:
+
+- **Code** — Fix bugs, add features, improve performance
+- **Documentation** — Fix typos, clarify instructions, write guides
+- **Design** — Improve UI, create icons, design logos
+- **Testing** — Report bugs, write tests, verify fixes
+- **Community** — Answer questions, review PRs, help newcomers
+- **Translation** — Make software accessible in more languages
+
+## Common Misconceptions
+
+**"I'm not good enough to contribute."**
+Every expert was once a beginner. Many projects have issues labeled `good first issue` specifically for newcomers. That's exactly where you should start.
+
+**"I need to write code."**
+Documentation, bug reports, and community support are just as valuable as code contributions.
+
+**"My contribution is too small to matter."**
+Fixing a single typo in documentation helps every future reader. No contribution is too small.
+
+## What's Next?
+
+Now that you know what open source is and why it matters, let's get your tools set up. Head to [Setting Up Git](02-setting-up-git.md).

--- a/guides/02-setting-up-git.md
+++ b/guides/02-setting-up-git.md
@@ -1,0 +1,106 @@
+# Setting Up Git
+
+Git is the version control system used by nearly every open source project. Before you can contribute, you need to install Git and configure it with your identity.
+
+## Step 1: Install Git
+
+### macOS
+
+Git comes pre-installed on most Macs. Open your terminal and check:
+
+```bash
+git --version
+```
+
+If it's not installed, you'll be prompted to install it. Alternatively, install it with [Homebrew](https://brew.sh):
+
+```bash
+brew install git
+```
+
+### Windows
+
+Download Git from [git-scm.com](https://git-scm.com/download/win) and run the installer. Use the default settings.
+
+After installation, open **Git Bash** (installed with Git) to use Git commands.
+
+### Linux
+
+Use your package manager:
+
+```bash
+# Ubuntu / Debian
+sudo apt update && sudo apt install git
+
+# Fedora
+sudo dnf install git
+```
+
+## Step 2: Configure Your Identity
+
+Git needs to know who you are so your contributions are attributed to you. Run these commands with your own name and email:
+
+```bash
+git config --global user.name "Your Name"
+git config --global user.email "your.email@example.com"
+```
+
+Use the same email address you use for your GitHub account so your commits are linked to your profile.
+
+## Step 3: Create a GitHub Account
+
+If you don't already have one, create a free account at [github.com](https://github.com).
+
+Your GitHub profile is where your contributions will appear. Choose a username you're happy with — it becomes part of your developer identity.
+
+## Step 4: Set Up Authentication
+
+To push code to GitHub, you need to authenticate. The recommended method is SSH keys.
+
+### Generate an SSH Key
+
+```bash
+ssh-keygen -t ed25519 -C "your.email@example.com"
+```
+
+Press Enter to accept the default file location, then set a passphrase (or press Enter for none).
+
+### Add Your Key to GitHub
+
+1. Copy your public key:
+
+```bash
+# macOS
+cat ~/.ssh/id_ed25519.pub | pbcopy
+
+# Linux
+cat ~/.ssh/id_ed25519.pub
+```
+
+2. Go to [GitHub SSH Settings](https://github.com/settings/keys)
+3. Click **New SSH key**
+4. Paste your key and save
+
+### Test the Connection
+
+```bash
+ssh -T git@github.com
+```
+
+You should see: `Hi username! You've successfully authenticated`.
+
+## Verify Your Setup
+
+Run these commands to confirm everything is working:
+
+```bash
+git --version
+git config user.name
+git config user.email
+```
+
+You should see your Git version, name, and email.
+
+## What's Next?
+
+Your tools are ready. Next, learn how to [Fork and Clone](03-forking-and-cloning.md) a repository.

--- a/guides/03-forking-and-cloning.md
+++ b/guides/03-forking-and-cloning.md
@@ -1,0 +1,85 @@
+# Forking and Cloning
+
+Before you can make changes to an open source project, you need your own copy of the code. This involves two steps: **forking** (creating your copy on GitHub) and **cloning** (downloading it to your computer).
+
+## What is a Fork?
+
+A fork is your personal copy of someone else's repository on GitHub. It lives under your GitHub account and is completely independent — you can make any changes you want without affecting the original project.
+
+When you're ready, you submit a **pull request** to propose merging your changes back into the original.
+
+## Step 1: Fork the Repository
+
+Let's practice with this repository:
+
+1. Go to the [LearnToContribute repository](https://github.com/ossnotify/LearnToContribute) on GitHub
+2. Click the **Fork** button in the top-right corner
+3. Select your GitHub account as the destination
+
+GitHub will create a copy at `https://github.com/YOUR-USERNAME/LearnToContribute`.
+
+## Step 2: Clone Your Fork
+
+Now download your fork to your computer:
+
+```bash
+git clone https://github.com/YOUR-USERNAME/LearnToContribute.git
+```
+
+Replace `YOUR-USERNAME` with your actual GitHub username.
+
+This creates a `LearnToContribute` folder on your computer with all the project files.
+
+```bash
+cd LearnToContribute
+```
+
+## Step 3: Add the Upstream Remote
+
+To keep your fork up to date with the original project, add it as a remote called `upstream`:
+
+```bash
+git remote add upstream https://github.com/ossnotify/LearnToContribute.git
+```
+
+Verify your remotes:
+
+```bash
+git remote -v
+```
+
+You should see:
+```
+origin    https://github.com/YOUR-USERNAME/LearnToContribute.git (fetch)
+origin    https://github.com/YOUR-USERNAME/LearnToContribute.git (push)
+upstream  https://github.com/ossnotify/LearnToContribute.git (fetch)
+upstream  https://github.com/ossnotify/LearnToContribute.git (push)
+```
+
+- **origin** — Your fork (where you push changes)
+- **upstream** — The original project (where you pull updates from)
+
+## Keeping Your Fork Up to Date
+
+Before starting new work, pull the latest changes from upstream:
+
+```bash
+git fetch upstream
+git merge upstream/main
+```
+
+This ensures your fork has the latest code from the original project.
+
+## Key Concepts
+
+| Term | What It Means |
+|------|---------------|
+| **Fork** | Your copy of a repo on GitHub |
+| **Clone** | Downloading a repo to your computer |
+| **Origin** | Your fork (remote) |
+| **Upstream** | The original project (remote) |
+| **Remote** | A version of the repo hosted on GitHub |
+
+## What's Next?
+
+You have a local copy of the project. Now let's [Make Your First Pull Request](04-making-your-first-pr.md).

--- a/guides/04-making-your-first-pr.md
+++ b/guides/04-making-your-first-pr.md
@@ -1,0 +1,127 @@
+# Making Your First Pull Request
+
+A pull request (PR) is how you propose changes to an open source project. You make changes in your fork, then ask the project maintainers to review and merge them.
+
+Let's walk through the entire process using this repository.
+
+## Step 1: Create a Branch
+
+Always create a new branch for your changes. Never work directly on `main`.
+
+```bash
+git checkout -b add-my-profile
+```
+
+This creates a new branch called `add-my-profile` and switches to it.
+
+### Why Branch?
+
+- Keeps your `main` branch clean and in sync with upstream
+- Each PR gets its own branch, so you can work on multiple contributions at once
+- Makes it easy to start over if something goes wrong
+
+## Step 2: Make Your Changes
+
+For your first PR, add your contributor profile. Create a new file in the `contributors/` directory:
+
+```bash
+cp contributors/example.json contributors/your-github-username.json
+```
+
+Open the file and fill in your details:
+
+```json
+{
+  "name": "Your Name",
+  "github": "your-github-username",
+  "skills": ["JavaScript", "Python"],
+  "message": "Excited to start contributing!"
+}
+```
+
+## Step 3: Stage Your Changes
+
+Tell Git which files you want to include in your commit:
+
+```bash
+git add contributors/your-github-username.json
+```
+
+Check what's staged:
+
+```bash
+git status
+```
+
+You should see your new file listed under "Changes to be committed."
+
+## Step 4: Commit Your Changes
+
+Save your changes with a descriptive message:
+
+```bash
+git commit -m "Add contributor profile for your-github-username"
+```
+
+A good commit message:
+- Starts with a verb (Add, Fix, Update, Remove)
+- Is short but descriptive
+- Explains what changed, not how
+
+## Step 5: Push to Your Fork
+
+Upload your branch to GitHub:
+
+```bash
+git push origin add-my-profile
+```
+
+## Step 6: Open the Pull Request
+
+1. Go to your fork on GitHub (`https://github.com/YOUR-USERNAME/LearnToContribute`)
+2. You'll see a banner saying your branch was recently pushed — click **Compare & pull request**
+3. Fill out the PR template:
+   - Write a clear title (e.g., "Add contributor profile for your-github-username")
+   - Describe what you changed in the body
+   - Check the relevant boxes in the checklist
+4. Click **Create pull request**
+
+## What Happens Next?
+
+After you submit your PR:
+
+1. **Automated checks** may run (like the welcome bot greeting you)
+2. A **maintainer reviews** your changes
+3. They may **request changes** — don't worry, this is normal and part of the process
+4. Once approved, your PR gets **merged** into the main project
+
+## Responding to Feedback
+
+If a maintainer requests changes:
+
+1. Make the changes on the same branch locally
+2. Commit and push again:
+
+```bash
+git add .
+git commit -m "Address review feedback"
+git push origin add-my-profile
+```
+
+Your PR will automatically update with the new changes.
+
+## After Your PR is Merged
+
+Clean up your local branches:
+
+```bash
+git checkout main
+git pull upstream main
+git branch -d add-my-profile
+```
+
+Congratulations — you've just made your first open source contribution!
+
+## What's Next?
+
+Learn about [Understanding Issues](05-understanding-issues.md) to find more ways to contribute.

--- a/guides/05-understanding-issues.md
+++ b/guides/05-understanding-issues.md
@@ -1,0 +1,91 @@
+# Understanding Issues
+
+Issues are how open source projects track bugs, feature requests, and tasks. Learning to read and work with issues is essential for finding meaningful contributions.
+
+## What Are Issues?
+
+GitHub issues are like a project's to-do list. They can represent:
+
+- **Bugs** — Something isn't working correctly
+- **Feature requests** — Ideas for new functionality
+- **Improvements** — Ways to make existing features better
+- **Questions** — Requests for help or clarification
+- **Tasks** — Work that needs to be done
+
+## Reading an Issue
+
+A well-written issue typically includes:
+
+- **Title** — A short description of the problem or request
+- **Description** — Details about what's expected vs. what's happening
+- **Labels** — Tags that categorize the issue (bug, enhancement, good first issue, etc.)
+- **Assignees** — Who's working on it
+- **Comments** — Discussion and updates from contributors
+
+## Finding Issues to Work On
+
+### Labels to Look For
+
+Most beginner-friendly projects use labels to flag easy issues:
+
+| Label | What It Means |
+|-------|---------------|
+| `good first issue` | Suitable for first-time contributors |
+| `help wanted` | Maintainers are looking for help |
+| `beginner` / `easy` | Low complexity |
+| `documentation` | Writing or fixing docs (no code needed) |
+| `bug` | Something is broken |
+| `enhancement` | An improvement to existing functionality |
+
+### Before You Start
+
+1. **Read the entire issue** — including all comments
+2. **Check if someone is already working on it** — look for linked PRs or comments saying "I'll take this"
+3. **Ask to be assigned** — Comment on the issue to let maintainers know you'd like to work on it
+4. **Understand the scope** — Make sure you know what a complete solution looks like
+
+## Working on an Issue
+
+### Claiming an Issue
+
+Leave a comment like:
+
+> "Hi! I'd like to work on this issue. Could you assign it to me?"
+
+Most maintainers will respond within a few days. If you don't hear back after a week, it's usually fine to start working on it anyway.
+
+### Linking Your PR to an Issue
+
+When you open your pull request, reference the issue number in the description:
+
+```
+Fixes #42
+```
+
+or
+
+```
+Closes #42
+```
+
+This tells GitHub to automatically close the issue when your PR is merged.
+
+### Common keywords that link PRs to issues:
+
+- `Fixes #123` — Closes the issue when merged
+- `Closes #123` — Same as Fixes
+- `Resolves #123` — Same as Fixes
+- `Related to #123` — Links without closing
+
+## Creating Issues
+
+You can also contribute by reporting bugs or suggesting features:
+
+1. Check if a similar issue already exists
+2. Use the project's issue template if available
+3. Be specific — include steps to reproduce, expected vs. actual behavior, and screenshots if relevant
+4. Be respectful — maintainers are often volunteers
+
+## What's Next?
+
+Now that you know how to find and work on issues, learn how to [Find Issues with OSS Notify](06-using-oss-notify.md) to automate the process.

--- a/guides/06-using-oss-notify.md
+++ b/guides/06-using-oss-notify.md
@@ -1,0 +1,75 @@
+# Finding Issues with OSS Notify
+
+You've learned the skills — setting up Git, forking repos, making pull requests, and understanding issues. Now it's time to find real open source issues to work on.
+
+Searching through thousands of GitHub repositories manually is overwhelming. [OSS Notify](https://www.ossnotify.com) solves this by matching issues to your skills and delivering them to your inbox.
+
+## What is OSS Notify?
+
+OSS Notify is a service that watches GitHub repositories for new issues and matches them to your skill set. Instead of browsing endlessly, you receive a curated digest of issues you can actually contribute to.
+
+## How It Works
+
+1. **Set your skills** — Tell OSS Notify what languages and frameworks you know (Python, JavaScript, React, Go, etc.)
+2. **Watch repositories** — Pick repos you care about or let OSS Notify recommend them
+3. **Get matched issues** — Receive email digests with issues filtered to your abilities
+4. **Start contributing** — Pick an issue, follow the workflow you learned in these guides, and submit your PR
+
+## Getting Started
+
+### 1. Sign Up
+
+Go to [ossnotify.com](https://www.ossnotify.com) and sign up with your GitHub account. Setup takes about 2 minutes.
+
+### 2. Configure Your Skills
+
+Select the languages and technologies you're comfortable with. Be honest — it's better to get issues you can actually solve than to be overwhelmed by ones you can't.
+
+If you're just starting out, pick 1-2 languages you know best.
+
+### 3. Watch Repositories
+
+You can:
+- **Search** for specific repos you're interested in
+- **Browse recommendations** based on your tech stack
+- **Discover** popular beginner-friendly projects
+
+### 4. Choose Your Digest Frequency
+
+- **Weekly** (free) — A weekly summary of matching issues
+- **Daily** (Pro) — A daily digest so you never miss an opportunity
+
+## Smart Features
+
+- **Label filtering** — Focus on `good first issue`, `help wanted`, or custom labels
+- **PR detection** — OSS Notify checks if an issue already has a linked pull request, so you don't waste time on issues already being addressed
+- **Skill matching** — Issues are ranked by how well they match your profile
+
+## Tips for Success
+
+1. **Start small** — Look for documentation fixes, typo corrections, or simple bug fixes
+2. **Be consistent** — Set aside regular time to check your digest and pick an issue
+3. **Follow up** — If you claim an issue, follow through. If you can't finish, let the maintainer know
+4. **Level up gradually** — As you gain confidence, expand your skills and watch more repositories
+
+## Your Journey So Far
+
+Here's what you've learned in these guides:
+
+1. [What open source is and why it matters](01-what-is-open-source.md)
+2. [How to set up Git and GitHub](02-setting-up-git.md)
+3. [How to fork and clone repositories](03-forking-and-cloning.md)
+4. [How to make pull requests](04-making-your-first-pr.md)
+5. [How to find and work on issues](05-understanding-issues.md)
+6. **How to use OSS Notify to find your next contribution** (you are here)
+
+## What's Next?
+
+You have everything you need to start contributing to open source. Here's your action plan:
+
+1. **[Add your contributor profile](../contributors/)** to this repo if you haven't already — it's great practice
+2. **[Sign up for OSS Notify](https://www.ossnotify.com)** to get issues matched to your skills
+3. **Pick an issue** from your first digest and follow the workflow from these guides
+4. **Make your first real contribution** to an open source project
+
+Welcome to the open source community. Happy contributing!


### PR DESCRIPTION

Set up LearnToContribute as a companion repo for OSS Notify with:
- Step-by-step guides (what is open source, Git setup, forking, PRs, issues, and using OSS Notify)
- Contributors practice area with JSON profile template
- GitHub issue/PR templates and first-time contributor welcome bot
- Code of Conduct (Contributor Covenant v2.1)
- Contributing guide with full fork-to-PR workflow